### PR TITLE
Refactor ConsensusMessage component to introduce view mode toggle for stacked and side-by-side layouts

### DIFF
--- a/src/components/ConsensusMessage.tsx
+++ b/src/components/ConsensusMessage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Brain, Clock, AlertCircle, ChevronDown, ChevronUp, Copy, Check } from 'lucide-react';
+import { Brain, Clock, AlertCircle, ChevronDown, ChevronUp, Copy, Check, List, Grid3X3 } from 'lucide-react';
 import { ConsensusResponse } from '@/types/chat';
 import { MarkdownRenderer } from './MarkdownRenderer';
 
@@ -10,9 +10,12 @@ interface ConsensusMessageProps {
   isStreaming?: boolean;
 }
 
+type ViewMode = 'stacked' | 'sideBySide';
+
 export function ConsensusMessage({ responses, isStreaming }: ConsensusMessageProps) {
   const [expandedModels, setExpandedModels] = useState<Set<string>>(new Set());
   const [copiedModel, setCopiedModel] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>('stacked');
 
   const getProviderLogo = (provider: string) => {
     const providerLogos: Record<string, string> = {
@@ -92,149 +95,75 @@ export function ConsensusMessage({ responses, isStreaming }: ConsensusMessagePro
             )}
           </div>
         )}
-      </div>
-
-      <div className="space-y-3">
-        {responses.map((response, index) => {
-          const modelInfo = formatModelName(response.model);
-          const isExpanded = expandedModels.has(response.model);
-          const hasContent = response.content && response.content.trim().length > 0;
-
-          return (
-            <div
-              key={response.model}
-              className={`glass-hover rounded-xl border transition-all duration-200 ${
-                response.error 
-                  ? 'border-red-400/30 bg-red-500/5' 
-                  : response.isLoading 
-                    ? 'border-yellow-400/30 bg-yellow-500/5' 
-                    : 'border-white/10'
+        
+        {/* View Mode Toggle */}
+        {responses.length > 1 && (
+          <div className="flex items-center gap-1 ml-3 p-1 glass-hover rounded-lg border border-white/10">
+            <button
+              onClick={() => setViewMode('stacked')}
+              className={`p-1.5 rounded transition-all ${
+                viewMode === 'stacked'
+                  ? 'bg-purple-500/20 text-purple-400'
+                  : 'text-white/40 hover:text-white/60 hover:bg-white/10'
               }`}
+              title="Stacked View"
             >
-              <div 
-                className="flex items-center gap-3 p-4 cursor-pointer"
-                onClick={() => hasContent && toggleExpanded(response.model)}
-              >
-                <div className="w-8 h-8 flex items-center justify-center rounded-lg glass border border-white/10">
-                  {modelInfo.logo ? (
-                    <img
-                      src={modelInfo.logo}
-                      alt={`${modelInfo.provider} logo`}
-                      className="w-5 h-5 object-contain"
-                      onError={(e) => {
-                        const target = e.target as HTMLImageElement;
-                        target.style.display = 'none';
-                        target.nextElementSibling?.classList.remove('hidden');
-                      }}
-                    />
-                  ) : null}
-                  <Brain 
-                    size={14} 
-                    className={`text-white/60 ${modelInfo.logo ? 'hidden' : ''}`}
-                  />
-                </div>
-
-                <div className="flex-1 min-w-0">
-                  <div className="font-medium text-white/90 truncate">
-                    {modelInfo.name}
-                  </div>
-                  <div className="text-sm text-white/50">
-                    {modelInfo.provider}
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-2">
-                  {response.error && (
-                    <div className="flex items-center gap-1 text-red-400 text-xs">
-                      <AlertCircle size={12} />
-                      Error
-                    </div>
-                  )}
-                  
-                  {response.isLoading && (
-                    <div className="flex items-center gap-1 text-yellow-400 text-xs">
-                      <div className="w-2 h-2 bg-yellow-400 rounded-full animate-pulse" />
-                      Loading...
-                    </div>
-                  )}
-
-                  {response.responseTime && (
-                    <div className="flex items-center gap-1 text-white/40 text-xs">
-                      <Clock size={12} />
-                      {formatResponseTime(response.responseTime)}
-                    </div>
-                  )}
-
-                  {hasContent && !response.isLoading && (
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        copyResponse(response.content, response.model);
-                      }}
-                      className="cursor-pointer p-1 rounded hover:bg-white/10 transition-colors"
-                    >
-                      {copiedModel === response.model ? (
-                        <Check size={14} className="text-green-400" />
-                      ) : (
-                        <Copy size={14} className="text-white/40 hover:text-white/60" />
-                      )}
-                    </button>
-                  )}
-
-                  {hasContent && (
-                    <button className="cursor-pointer p-1 rounded hover:bg-white/10 transition-colors">
-                      {isExpanded ? (
-                        <ChevronUp size={16} className="text-white/40" />
-                      ) : (
-                        <ChevronDown size={16} className="text-white/40" />
-                      )}
-                    </button>
-                  )}
-                </div>
-              </div>
-
-              {hasContent && isExpanded && (
-                <div className="px-4 pb-4 border-t border-white/10">
-                  <div className="mt-4">
-                    <MarkdownRenderer content={response.content} />
-                  </div>
-                </div>
-              )}
-
-              {response.error && (
-                <div className="px-4 pb-4 border-t border-red-400/20">
-                  <div className="mt-4 p-3 bg-red-500/10 border border-red-400/20 rounded-lg">
-                    <div className="text-red-400 text-sm font-medium mb-1">Error</div>
-                    <div className="text-red-300/80 text-sm">{response.error}</div>
-                  </div>
-                </div>
-              )}
-
-              {response.isLoading && (
-                <div className="px-4 pb-4 border-t border-yellow-400/20">
-                  <div className="mt-4 p-3 bg-yellow-500/10 border border-yellow-400/20 rounded-lg">
-                    <div className="flex items-center gap-2 text-yellow-400 text-sm">
-                      <div className="w-2 h-2 bg-yellow-400 rounded-full animate-pulse" />
-                      Waiting for response...
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {response.isStreaming && hasContent && !isExpanded && (
-                <div className="px-4 pb-4 border-t border-white/10">
-                  <div className="mt-4 text-white/70 text-sm line-clamp-2">
-                    {response.content.substring(0, 150)}
-                    {response.content.length > 150 && '...'}
-                  </div>
-                </div>
-              )}
-            </div>
-          );
-        })}
+              <List size={14} />
+            </button>
+            <button
+              onClick={() => setViewMode('sideBySide')}
+              className={`p-1.5 rounded transition-all ${
+                viewMode === 'sideBySide'
+                  ? 'bg-purple-500/20 text-purple-400'
+                  : 'text-white/40 hover:text-white/60 hover:bg-white/10'
+              }`}
+              title="Side by Side View"
+            >
+              <Grid3X3 size={14} />
+            </button>
+          </div>
+        )}
       </div>
 
-      {completedResponses.length > 1 && (
+      {viewMode === 'stacked' ? (
+        <div className="space-y-3">
+          {responses.map((response, index) => (
+            <ModelResponseCard
+              key={response.model}
+              response={response}
+              isExpanded={expandedModels.has(response.model)}
+              copiedModel={copiedModel}
+              onToggleExpanded={toggleExpanded}
+              onCopyResponse={copyResponse}
+              formatModelName={formatModelName}
+              formatResponseTime={formatResponseTime}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className={`grid gap-4 ${
+          responses.length === 2 ? 'grid-cols-1 lg:grid-cols-2' :
+          responses.length === 3 ? 'grid-cols-1 lg:grid-cols-3' :
+          responses.length >= 4 ? 'grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4' :
+          'grid-cols-1'
+        }`}>
+          {responses.map((response, index) => (
+            <ModelResponseCard
+              key={response.model}
+              response={response}
+              isExpanded={true} // Always expanded in side-by-side view
+              copiedModel={copiedModel}
+              onToggleExpanded={toggleExpanded}
+              onCopyResponse={copyResponse}
+              formatModelName={formatModelName}
+              formatResponseTime={formatResponseTime}
+              isSideBySide={true}
+            />
+          ))}
+        </div>
+      )}
+
+      {completedResponses.length > 1 && viewMode === 'stacked' && (
         <div className="flex items-center gap-2 p-3 glass-hover rounded-xl border border-white/10">
           <div className="text-sm text-white/60 flex-1">
             Compare responses from {completedResponses.length} models
@@ -254,6 +183,163 @@ export function ConsensusMessage({ responses, isStreaming }: ConsensusMessagePro
           >
             Collapse All
           </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Extract ModelResponseCard as a separate component for reusability
+interface ModelResponseCardProps {
+  response: ConsensusResponse;
+  isExpanded: boolean;
+  copiedModel: string | null;
+  onToggleExpanded: (model: string) => void;
+  onCopyResponse: (content: string, model: string) => void;
+  formatModelName: (model: string) => { name: string; provider: string; logo: string | null };
+  formatResponseTime: (ms: number) => string;
+  isSideBySide?: boolean;
+}
+
+function ModelResponseCard({
+  response,
+  isExpanded,
+  copiedModel,
+  onToggleExpanded,
+  onCopyResponse,
+  formatModelName,
+  formatResponseTime,
+  isSideBySide = false
+}: ModelResponseCardProps) {
+  const modelInfo = formatModelName(response.model);
+  const hasContent = response.content && response.content.trim().length > 0;
+
+  return (
+    <div
+      className={`glass-hover rounded-xl border transition-all duration-200 ${
+        response.error 
+          ? 'border-red-400/30 bg-red-500/5' 
+          : response.isLoading 
+            ? 'border-yellow-400/30 bg-yellow-500/5' 
+            : 'border-white/10'
+      } ${isSideBySide ? 'h-full flex flex-col' : ''}`}
+    >
+      <div 
+        className={`flex items-center gap-3 p-4 ${hasContent && !isSideBySide ? 'cursor-pointer' : ''}`}
+        onClick={() => hasContent && !isSideBySide && onToggleExpanded(response.model)}
+      >
+        <div className="w-8 h-8 flex items-center justify-center rounded-lg glass border border-white/10">
+          {modelInfo.logo ? (
+            <img
+              src={modelInfo.logo}
+              alt={`${modelInfo.provider} logo`}
+              className="w-5 h-5 object-contain"
+              onError={(e) => {
+                const target = e.target as HTMLImageElement;
+                target.style.display = 'none';
+                target.nextElementSibling?.classList.remove('hidden');
+              }}
+            />
+          ) : null}
+          <Brain 
+            size={14} 
+            className={`text-white/60 ${modelInfo.logo ? 'hidden' : ''}`}
+          />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="font-medium text-white/90 truncate">
+            {modelInfo.name}
+          </div>
+          <div className="text-sm text-white/50">
+            {modelInfo.provider}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {response.error && (
+            <div className="flex items-center gap-1 text-red-400 text-xs">
+              <AlertCircle size={12} />
+              Error
+            </div>
+          )}
+          
+          {response.isLoading && (
+            <div className="flex items-center gap-1 text-yellow-400 text-xs">
+              <div className="w-2 h-2 bg-yellow-400 rounded-full animate-pulse" />
+              Loading...
+            </div>
+          )}
+
+          {response.responseTime && (
+            <div className="flex items-center gap-1 text-white/40 text-xs">
+              <Clock size={12} />
+              {formatResponseTime(response.responseTime)}
+            </div>
+          )}
+
+          {hasContent && !response.isLoading && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onCopyResponse(response.content, response.model);
+              }}
+              className="cursor-pointer p-1 rounded hover:bg-white/10 transition-colors"
+            >
+              {copiedModel === response.model ? (
+                <Check size={14} className="text-green-400" />
+              ) : (
+                <Copy size={14} className="text-white/40 hover:text-white/60" />
+              )}
+            </button>
+          )}
+
+          {hasContent && !isSideBySide && (
+            <button className="cursor-pointer p-1 rounded hover:bg-white/10 transition-colors">
+              {isExpanded ? (
+                <ChevronUp size={16} className="text-white/40" />
+              ) : (
+                <ChevronDown size={16} className="text-white/40" />
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {hasContent && (isExpanded || isSideBySide) && (
+        <div className={`px-4 pb-4 border-t border-white/10 ${isSideBySide ? 'flex-1 overflow-hidden' : ''}`}>
+          <div className={`mt-4 ${isSideBySide ? 'h-full overflow-y-auto' : ''}`}>
+            <MarkdownRenderer content={response.content} />
+          </div>
+        </div>
+      )}
+
+      {response.error && (
+        <div className="px-4 pb-4 border-t border-red-400/20">
+          <div className="mt-4 p-3 bg-red-500/10 border border-red-400/20 rounded-lg">
+            <div className="text-red-400 text-sm font-medium mb-1">Error</div>
+            <div className="text-red-300/80 text-sm">{response.error}</div>
+          </div>
+        </div>
+      )}
+
+      {response.isLoading && (
+        <div className="px-4 pb-4 border-t border-yellow-400/20">
+          <div className="mt-4 p-3 bg-yellow-500/10 border border-yellow-400/20 rounded-lg">
+            <div className="flex items-center gap-2 text-yellow-400 text-sm">
+              <div className="w-2 h-2 bg-yellow-400 rounded-full animate-pulse" />
+              Waiting for response...
+            </div>
+          </div>
+        </div>
+      )}
+
+      {response.isStreaming && hasContent && !isExpanded && !isSideBySide && (
+        <div className="px-4 pb-4 border-t border-white/10">
+          <div className="mt-4 text-white/70 text-sm line-clamp-2">
+            {response.content.substring(0, 150)}
+            {response.content.length > 150 && '...'}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
This pull request introduces a new feature to the `ConsensusMessage` component: a toggleable view mode that allows users to switch between a "stacked" and "side-by-side" layout for displaying model responses. Additionally, the `ModelResponseCard` has been extracted into a reusable component to improve code organization and maintainability.

### New Feature: View Mode Toggle
* Added a `viewMode` state with two options: `'stacked'` and `'sideBySide'`. This state determines how model responses are displayed.
* Implemented a toggle UI with buttons to switch between the two view modes. The buttons use icons (`List` and `Grid3X3`) from the `lucide-react` library.

### Layout Adjustments for View Modes
* In "stacked" mode, responses are displayed in a vertical list, with expandable/collapsible sections for each response.
* In "side-by-side" mode, responses are displayed in a responsive grid layout, with all sections expanded by default and scrollable content areas. [[1]](diffhunk://#diff-26aa116931c4e38fd510bec3437dd8f0290a45228c78e599ce971dc87775420bR98-R229) [[2]](diffhunk://#diff-26aa116931c4e38fd510bec3437dd8f0290a45228c78e599ce971dc87775420bL196-R311)

### Code Refactoring: Extracting `ModelResponseCard`
* Extracted the `ModelResponseCard` component from the main `ConsensusMessage` function. This new component handles the rendering of individual model responses, making the code more modular and reusable.
* Updated the `ModelResponseCard` to support both view modes by introducing an `isSideBySide` prop that adjusts its behavior and styling. [[1]](diffhunk://#diff-26aa116931c4e38fd510bec3437dd8f0290a45228c78e599ce971dc87775420bR98-R229) [[2]](diffhunk://#diff-26aa116931c4e38fd510bec3437dd8f0290a45228c78e599ce971dc87775420bL196-R311)

### Minor Adjustments
* Updated event handling and conditional rendering logic to accommodate the new view modes. For example, the "expand/collapse" functionality is disabled in "side-by-side" mode. [[1]](diffhunk://#diff-26aa116931c4e38fd510bec3437dd8f0290a45228c78e599ce971dc87775420bL184-R297) [[2]](diffhunk://#diff-26aa116931c4e38fd510bec3437dd8f0290a45228c78e599ce971dc87775420bL234-L260)
* Added new icons (`List` and `Grid3X3`) to the `lucide-react` import for the toggle buttons.