### PR TITLE
Feature/chat renaming

### DIFF
--- a/src/components/ChatSidebar.tsx
+++ b/src/components/ChatSidebar.tsx
@@ -335,7 +335,8 @@ export function ChatSidebar({ isCollapsed, onToggleCollapse }: ChatSidebarProps)
                                     value={editTitle}
                                     onChange={(e) => setEditTitle(e.target.value)}
                                     onKeyDown={(e) => handleKeyDown(e, conversation.id)}
-                                    className="text-xs font-medium bg-white/10 border border-white/20 rounded px-2 py-1 text-white flex-1 focus:outline-none focus:ring-1 focus:ring-white/40"
+                                    className="text-xs font-medium bg-white/10 border border-white/20 rounded px-2 py-1 text-white focus:outline-none focus:ring-1 focus:ring-white/40"
+                                    style={{ width: 'calc(100% - 80px)' }}
                                     autoFocus
                                     onFocus={(e) => e.target.select()}
                                   />

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -19,6 +19,7 @@ interface ChatContextType {
   createNewConversation: () => void;
   deleteConversation: (conversationId: string) => Promise<void>;
   updateConversationTitle: (conversationId: string, newTitle: string) => void;
+  renameConversation: (conversationId: string, newTitle: string) => Promise<boolean>;
   addNewConversation: (conversation: Conversation) => void;
   addOptimisticMessage: (message: Omit<Message, 'id' | 'created_at'>) => string;
   updateStreamingMessage: (messageId: string, content: string) => void;
@@ -213,6 +214,31 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const renameConversation = async (conversationId: string, newTitle: string): Promise<boolean> => {
+    try {
+      const response = await fetch(`/api/conversations?id=${conversationId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ title: newTitle }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        // Update local state with the updated conversation
+        updateConversationTitle(conversationId, data.conversation.title);
+        return true;
+      } else {
+        console.error('Failed to rename conversation:', await response.text());
+        return false;
+      }
+    } catch (error) {
+      console.error('Error renaming conversation:', error);
+      return false;
+    }
+  };
+
   const addNewConversation = (conversation: Conversation) => {
     setConversations(prev => [conversation, ...prev]);
     setNewConversationIds(prev => new Set([...prev, conversation.id]));
@@ -276,6 +302,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         createNewConversation,
         deleteConversation,
         updateConversationTitle,
+        renameConversation,
         addNewConversation,
         addOptimisticMessage,
         updateStreamingMessage,


### PR DESCRIPTION
This pull request introduces functionality to rename conversations, including backend API support, UI updates, and integration with the chat context. The changes focus on enabling users to edit conversation titles directly from the sidebar while ensuring proper state management and error handling.

### Backend Changes
* Added a new `PATCH` method in `src/app/api/conversations/route.ts` to handle conversation title updates via the Supabase database. This includes validation for user authentication, conversation ID, and title.

### UI Enhancements
* Updated `src/components/ChatSidebar.tsx` to include UI elements for renaming conversations:
  - Added an edit button (`Edit3` icon) and an input field for editing titles directly in the sidebar. [[1]](diffhunk://#diff-f06e4581ebd9cb1e4deabb8472aeec1d0c9c177e3bad2716699889e516888db2L8-R8) [[2]](diffhunk://#diff-f06e4581ebd9cb1e4deabb8472aeec1d0c9c177e3bad2716699889e516888db2L285-L303)
  - Implemented handlers for saving, canceling, and keyboard shortcuts (Enter/Escape) for title edits.
  - Modified conversation list item styles to reflect editing and deleting states. [[1]](diffhunk://#diff-f06e4581ebd9cb1e4deabb8472aeec1d0c9c177e3bad2716699889e516888db2L238-R292) [[2]](diffhunk://#diff-f06e4581ebd9cb1e4deabb8472aeec1d0c9c177e3bad2716699889e516888db2L323-R435) [[3]](diffhunk://#diff-f06e4581ebd9cb1e4deabb8472aeec1d0c9c177e3bad2716699889e516888db2R465-R484)

### State Management
* Extended `ChatContext` in `src/contexts/ChatContext.tsx` with a new `renameConversation` method to interact with the backend API and update local state. [[1]](diffhunk://#diff-3ac2df558bf74aed6641b315ffd49311e85f409d086f2a47fc3b6855a285b7b2R22) [[2]](diffhunk://#diff-3ac2df558bf74aed6641b315ffd49311e85f409d086f2a47fc3b6855a285b7b2R217-R241) [[3]](diffhunk://#diff-3ac2df558bf74aed6641b315ffd49311e85f409d086f2a47fc3b6855a285b7b2R305)